### PR TITLE
Reading history file fails with non-latin chars on Windows

### DIFF
--- a/pyreadline3/lineeditor/history.py
+++ b/pyreadline3/lineeditor/history.py
@@ -85,12 +85,11 @@ class LineHistory(object):
         if filename is None:
             filename = self.history_filename
         try:
-            with io.open(filename, 'rt', encoding=pyreadline_codepage) as fd:
+            with io.open(
+                filename, 'rt', encoding=pyreadline_codepage, errors='replace'
+            ) as fd:
                 for line in fd:
-                    self.add_history(
-                        lineobj.ReadLineTextBuffer(
-                            ensure_unicode(
-                                line.rstrip())))
+                    self.add_history(lineobj.ReadLineTextBuffer(line.rstrip()))
         except IOError:
             self.history = []
             self.history_cursor = 0
@@ -99,10 +98,11 @@ class LineHistory(object):
         '''Save a readline history file.'''
         if filename is None:
             filename = self.history_filename
-        with io.open(filename, 'wb') as fp:
+        with io.open(
+            filename, 'wt', encoding=pyreadline_codepage, errors='replace'
+        ) as fp:
             for line in self.history[-self.history_length:]:
-                fp.write(ensure_str(line.get_line_text()))
-                fp.write('\n'.encode(pyreadline_codepage))
+                fp.writeln(line.get_line_text())
 
     def add_history(self, line):
         '''Append a line to the history buffer, as if it was the last line typed.'''

--- a/pyreadline3/lineeditor/history.py
+++ b/pyreadline3/lineeditor/history.py
@@ -7,12 +7,13 @@
 #  the file COPYING, distributed as part of this software.
 # *****************************************************************************
 from __future__ import absolute_import, print_function, unicode_literals
+import re, operator, string, sys, os, io
 
 import os
 import sys
 
 from pyreadline3.logger import log
-from pyreadline3.unicode_helper import ensure_str, ensure_unicode
+from pyreadline3.unicode_helper import ensure_str, ensure_unicode, pyreadline_codepage
 
 if "pyreadline3" in sys.modules:
     pyreadline3 = sys.modules["pyreadline3"]
@@ -84,11 +85,12 @@ class LineHistory(object):
         if filename is None:
             filename = self.history_filename
         try:
-            for line in open(filename, 'r', encoding='utf-8'):
-                self.add_history(
-                    lineobj.ReadLineTextBuffer(
-                        ensure_unicode(
-                            line.rstrip())))
+            with io.open(filename, 'rt', encoding=pyreadline_codepage) as fd:
+                for line in fd:
+                    self.add_history(
+                        lineobj.ReadLineTextBuffer(
+                            ensure_unicode(
+                                line.rstrip())))
         except IOError:
             self.history = []
             self.history_cursor = 0
@@ -97,11 +99,10 @@ class LineHistory(object):
         '''Save a readline history file.'''
         if filename is None:
             filename = self.history_filename
-        fp = open(filename, 'wb')
-        for line in self.history[-self.history_length:]:
-            fp.write(ensure_str(line.get_line_text()))
-            fp.write('\n'.encode('ascii'))
-        fp.close()
+        with io.open(filename, 'wb') as fp:
+            for line in self.history[-self.history_length:]:
+                fp.write(ensure_str(line.get_line_text()))
+                fp.write('\n'.encode(pyreadline_codepage))
 
     def add_history(self, line):
         '''Append a line to the history buffer, as if it was the last line typed.'''

--- a/pyreadline3/lineeditor/history.py
+++ b/pyreadline3/lineeditor/history.py
@@ -13,7 +13,7 @@ import os
 import sys
 
 from pyreadline3.logger import log
-from pyreadline3.unicode_helper import ensure_str, ensure_unicode, pyreadline_codepage
+from pyreadline3.unicode_helper import ensure_str, ensure_unicode
 
 if "pyreadline3" in sys.modules:
     pyreadline3 = sys.modules["pyreadline3"]
@@ -86,7 +86,7 @@ class LineHistory(object):
             filename = self.history_filename
         try:
             with io.open(
-                filename, 'rt', encoding=pyreadline_codepage, errors='replace'
+                filename, 'rt', errors='replace'
             ) as fd:
                 for line in fd:
                     self.add_history(lineobj.ReadLineTextBuffer(line.rstrip()))
@@ -99,7 +99,7 @@ class LineHistory(object):
         if filename is None:
             filename = self.history_filename
         with io.open(
-            filename, 'wt', encoding=pyreadline_codepage, errors='replace'
+            filename, 'wt', errors='replace'
         ) as fp:
             for line in self.history[-self.history_length:]:
                 fp.writeln(line.get_line_text())

--- a/pyreadline3/unicode_helper.py
+++ b/pyreadline3/unicode_helper.py
@@ -27,7 +27,7 @@ def ensure_unicode(text):
         try:
             return text.decode(pyreadline_codepage, "replace")
         except (LookupError, TypeError):
-            return text.decode("ascii", "replace")
+            return text.decode(errors="replace")
     return text
 
 
@@ -37,7 +37,7 @@ def ensure_str(text):
         try:
             return text.encode(pyreadline_codepage, "replace")
         except (LookupError, TypeError):
-            return text.encode("ascii", "replace")
+            return text.encode(errors="replace")
     return text
 
 

--- a/pyreadline3/unicode_helper.py
+++ b/pyreadline3/unicode_helper.py
@@ -8,15 +8,17 @@
 # *****************************************************************************
 import sys
 
+#: Also support non-latin chars.
+_pyreadline_fallback_codepage = 'utf-8'
 try:
     pyreadline_codepage = sys.stdout.encoding
 except AttributeError:
     # This error occurs when pdb imports readline and doctest has replaced
     # stdout with stdout collector. We will assume ascii codepage
-    pyreadline_codepage = "ascii"
+    pyreadline_codepage = _pyreadline_fallback_codepage
 
 if pyreadline_codepage is None:
-    pyreadline_codepage = "ascii"
+    pyreadline_codepage = _pyreadline_fallback_codepage
 
 
 def ensure_unicode(text):


### PR DESCRIPTION
A band-aid PR that fixes pyreadline/pyreadline#49 and pyreadline/pyreadline/#55 on non-latin commands in history-file.