### PR TITLE
Add a Dependabot config to maintain action versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This repo currently uses ancient GitHub action versions that are throwing deprecation warnings ([recent example](https://github.com/pyreadline3/pyreadline3/actions/runs/10934516718)):

> ![image](https://github.com/user-attachments/assets/ccee7ddc-9596-4956-b9b0-a28e8e29e866)

Instead of updating these once, this PR introduces a Dependabot config. Dependabot will monitor the action versions and submit a PR _at most_ once per month.

If this PR is accepted and merges, you can expect Dependabot to immediately open a single PR to update `actions/checkout` to v4 and `actions/setup-python` to v5.